### PR TITLE
BREAKING Replace options with state and add optional callback

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,85 +1,94 @@
 var JsonCalendar = require("./index");
 
-var subject = new JsonCalendar();
-
 test("exports a class", () => {
-  expect(subject instanceof JsonCalendar).toBe(true);
+  var calendar = new JsonCalendar();
+  expect(calendar instanceof JsonCalendar).toBe(true);
+  expect(typeof calendar.state.year).toBe("number");
+  expect(typeof calendar.state.monthIndex).toBe("number");
 });
 
-test("has day names", () => {
-  expect(Array.isArray(subject.dayNames)).toBe(true);
-  expect(Array.isArray(subject.data.dayNames)).toBe(true);
-});
-
-test("has month names", () => {
-  expect(Array.isArray(subject.monthNames)).toBe(true);
+test("exports a class", async () => {
+  var callback = jest.fn();
+  var calendar = new JsonCalendar({}, callback);
+  await calendar;
+  expect(callback.mock.calls[0][0].weeks).toEqual(expect.arrayContaining([]));
 });
 
 test("has today's date", () => {
   const today = new Date();
-  expect(subject.today instanceof Date).toBe(true);
-  expect(subject.today.getFullYear()).toBe(today.getFullYear());
-  expect(subject.today.getHours()).toBe(0);
-  expect(subject.today.getMinutes()).toBe(0);
-  expect(subject.today.getHours()).toBe(0);
+  const calendar = new JsonCalendar();
+  const state = calendar.state;
+  expect(state.today instanceof Date).toBe(true);
+  expect(state.today.getFullYear()).toBe(today.getFullYear());
+  expect(state.today.getHours()).toBe(0);
+  expect(state.today.getMinutes()).toBe(0);
+  expect(state.today.getHours()).toBe(0);
 });
 
 test("uses given today param", () => {
   var today = new Date(2018, 12, 31, 0, 0);
   var calendar = new JsonCalendar({ today });
-  expect(calendar.today instanceof Date).toBe(true);
-  expect(calendar.today.getFullYear()).toBe(today.getFullYear());
-  expect(calendar.today.getMonth()).toBe(today.getMonth());
-  expect(calendar.today.getHours()).toBe(0);
-  expect(calendar.today.getMinutes()).toBe(0);
-  expect(calendar.today.getHours()).toBe(0);
+  var state = calendar.state;
+  expect(state.today instanceof Date).toBe(true);
+  expect(state.today.getFullYear()).toBe(today.getFullYear());
+  expect(state.today.getMonth()).toBe(today.getMonth());
+  expect(state.today.getHours()).toBe(0);
+  expect(state.today.getMinutes()).toBe(0);
+  expect(state.today.getHours()).toBe(0);
 });
 
 test("uses given today param and no abbr", () => {
   var today = new Date(2018, 12, 31, 0, 0);
-  var calendar = new JsonCalendar({ abbreviate: 0, today });
-  expect(calendar.options.abbreviate).toBe(0);
-  expect(calendar.data.dayNames[0].abbr).toBe(undefined);
+  var calendar = new JsonCalendar({ today });
+  expect(calendar.state.abbreviate).toBe(0);
+  expect(calendar.dayNames[0]).toBe("Sunday");
+  expect(calendar.dayNames[6]).toBe("Saturday");
 });
 
 test("uses given today param and abbr", () => {
   var today = new Date(2018, 12, 31, 0, 0);
   var calendar = new JsonCalendar({ abbreviate: 3, today });
-  expect(calendar.options.abbreviate).toBe(3);
-  expect(calendar.data.dayNames[0].abbr).toBe("Sun");
+  expect(calendar.state.abbreviate).toBe(3);
+  expect(calendar.dayNames[0]).toBe("Sun");
+  expect(calendar.dayNames[6]).toBe("Sat");
 });
 
 test("uses given today param, language, and abbr", () => {
   var today = new Date(2018, 12, 31, 0, 0);
   var calendar = new JsonCalendar({ abbreviate: 3, language: "french", today });
-  expect(calendar.options.abbreviate).toBe(3);
-  expect(calendar.data.dayNames[0].abbr).toBe("Dim");
+  expect(calendar.state.abbreviate).toBe(3);
+  expect(calendar.dayNames[0]).toBe("Dim");
 });
 
 test("has week arrays with 7 days", () => {
-  const lastWeekIndex = subject.weeks.length - 1;
-  expect(subject.weeks[0].length).toBe(7);
-  expect(subject.weeks[lastWeekIndex].length).toBe(7);
-  expect(typeof subject.weeks[1][1].className).toBe("string");
+  const calendar = new JsonCalendar();
+  const state = calendar.state;
+  const lastWeekIndex = state.weeks.length - 1;
+  expect(state.weeks[0].length).toBe(7);
+  expect(state.weeks[lastWeekIndex].length).toBe(7);
+  expect(typeof state.weeks[1][1].className).toBe("string");
 });
 
 test("displays October 2018 correctly", () => {
-  var today = new Date(2018, 12, 1, 0, 0);
+  var today = new Date(2018, 11, 1, 0, 0);
   var calendar = new JsonCalendar({ year: 2018, monthIndex: 9, today });
-  expect(calendar.weeks[0][0].day).toBe(30);
-  expect(calendar.weeks[0][0].date.getMonth()).toBe(8);
-  expect(calendar.weeks[0][1].day).toBe(1);
-  expect(calendar.weeks[0][1].date.getMonth()).toBe(9);
+  var state = calendar.state;
+  expect(state.weeks[0][0].day).toBe(30);
+  expect(state.weeks[0][0].date.getMonth()).toBe(8);
+  expect(state.weeks[0][1].day).toBe(1);
+  expect(state.weeks[0][1].date.getMonth()).toBe(9);
 });
 
 test("add days to date", () => {
+  const calendar = new JsonCalendar();
   const date = new Date(2018, 8, 29, 0, 0);
-  expect(subject.addDaysToDate(date, 0).getDate()).toBe(date.getDate());
-  expect(subject.addDaysToDate(date, -3).getDate()).toBe(26);
-  expect(subject.addDaysToDate(date, 10).getDate()).toBe(9);
+  expect(calendar.addDaysToDate(date, 0).getDate()).toBe(date.getDate());
+  expect(calendar.addDaysToDate(date, -3).getDate()).toBe(26);
+  expect(calendar.addDaysToDate(date, 10).getDate()).toBe(9);
 });
 
 test("creates a date without time", () => {
+  var subject = new JsonCalendar();
   var date = subject.createDate(2018, 11, 32, 0, 0);
   expect(date instanceof Date).toBe(true);
   expect(date.getFullYear()).toBe(2019);
@@ -91,8 +100,8 @@ test("creates a date without time", () => {
 
 test("get days in month", () => {
   var subject = new JsonCalendar({ today: new Date(2015, 4, 23) });
-  expect(subject.options.monthIndex).toBe(4);
-  expect(subject.options.year).toBe(2015);
+  expect(subject.state.monthIndex).toBe(4);
+  expect(subject.state.year).toBe(2015);
   expect(subject.getDaysInMonth()).toBe(31);
   expect(subject.getDaysInMonth(2015)).toBe(31);
   expect(subject.getDaysInMonth(2018, 4)).toBe(31);
@@ -103,11 +112,18 @@ test("get days in month", () => {
   expect(subject.getDaysInMonth(2008, 1)).toBe(29);
 });
 
-test("accepts change month", () => {
+test("accepts change of month", () => {
   const calendar = new JsonCalendar();
-  calendar.changeMonth(2019, 3);
-  expect(calendar.options.monthIndex).toBe(3);
-  expect(calendar.options.year).toBe(2019);
+  calendar.createWeeksForMonth(0);
+  expect(calendar.state.monthIndex).toBe(0);
+  expect(calendar.state.year).toBe(new Date().getFullYear());
+});
+
+test("accepts change of month and year", () => {
+  const calendar = new JsonCalendar();
+  calendar.createWeeksForMonth(3, 2020);
+  expect(calendar.state.monthIndex).toBe(3);
+  expect(calendar.state.year).toBe(2020);
 });
 
 describe("uses firstDayOfWeek param", () => {
@@ -118,8 +134,8 @@ describe("uses firstDayOfWeek param", () => {
       firstDayOfWeek: 0
     });
 
-    expect(calendar.options.firstDayOfWeek).toBe(0);
-    expect(calendar.weeks[0][0].day).toBe(27);
+    expect(calendar.state.firstDayOfWeek).toBe(0);
+    expect(calendar.state.weeks[0][0].day).toBe(27);
   });
 
   test("month starts on correct day when firstDayOfWeek is 1", () => {
@@ -129,29 +145,29 @@ describe("uses firstDayOfWeek param", () => {
       firstDayOfWeek: 1
     });
 
-    expect(calendar.options.firstDayOfWeek).toBe(1);
-    expect(calendar.weeks[0][0].day).toBe(28);
+    expect(calendar.state.firstDayOfWeek).toBe(1);
+    expect(calendar.state.weeks[0][0].day).toBe(28);
   });
 });
 
 describe("language parameter in constructor", () => {
   test("constructor optionally accepts a language", () => {
     let calendar = new JsonCalendar({ language: "french" });
-    expect(calendar.options.language).toBe("french");
+    expect(calendar.state.language).toBe("french");
 
     calendar = new JsonCalendar();
-    expect(calendar.options.language).toBe("english");
+    expect(calendar.state.language).toBe("english");
   });
 
   test("optional language param accept french or spanish, otherwise defaults to english", () => {
     let calendar = new JsonCalendar({ language: "spanish" });
-    expect(calendar.options.language).toBe("spanish");
+    expect(calendar.state.language).toBe("spanish");
 
     calendar = new JsonCalendar({ language: "french" });
-    expect(calendar.options.language).toBe("french");
+    expect(calendar.state.language).toBe("french");
 
     calendar = new JsonCalendar({ language: "esperanto" });
-    expect(calendar.options.language).toBe("english");
+    expect(calendar.state.language).toBe("english");
   });
 });
 


### PR DESCRIPTION
Relates to #9 

### What's Changed?

The one about this being a calendar state machine for displaying a UI

* custom values are set to `props` instead of `params`
* output is returned to a `state` object
* an optional callback is available to triggered when something changes
