### PR TITLE
Support the firstDayOfWeek param

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,9 +96,10 @@ class Calendar {
     // Loop through week indexes (0..6)
     for (var w = 0; w < 6; w++) {
       week = [];
+      var { firstDayOfWeek } = this.options;
 
       // Loop through the day index (0..6) for each week.
-      for (var d = 0; d < 7; d++) {
+      for (var d = firstDayOfWeek; d < firstDayOfWeek + 7; d++) {
         classNames = [];
         day = {};
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     },
     "globals": {
       "expect": true,
-      "test": true
+      "test": true,
+      "describe": true
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -78,3 +78,24 @@ test("accepts change month", () => {
   expect(calendar.options.monthIndex).toBe(3);
   expect(calendar.options.year).toBe(2019);
 });
+
+describe("uses firstDayOfWeek param", () => {
+  test("month starts on correct day when firstDayOfWeek is 0", () => {
+    const calendar = new JsonCalendar({
+      year: 2019,
+      monthIndex: 1,
+      firstDayOfWeek: 0
+    });
+
+    expect(calendar.weeks[0][0].day).toBe(27);
+  });
+  test("month starts on correct day when firstDayOfWeek is 1", () => {
+    const calendar = new JsonCalendar({
+      year: 2019,
+      monthIndex: 1,
+      firstDayOfWeek: 1
+    });
+
+    expect(calendar.weeks[0][0].day).toBe(28);
+  });
+});


### PR DESCRIPTION
Adds tests and implementation to support the `firstDayOfWeek` parameters specified in the default options object, to be able to create a calendar model where the first day of the week is a Monday.