### PR TITLE
Problem: End user being passed days / months names in english only, n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ var data = new Calendar();
 
 // with custom today date
 var  = new Calendar({ today: new Date(1971, 0, 1) });
+
+// with language for days / months name
+var calendarWithSpanishNames = new Calendar({ language: 'spanish' 
+
+/**
+* 'french', 'spanish' and 'english' supported, will default to 'english' if empty or unrecognized 
+*/ 
+
+}); 
+
+calendarWithSpanishName.dayNames
+
+[ 'Domingo',
+  'Lunes',
+  'Martes',
+  'Miércoles',
+  'Jueves',
+  'Viernes',
+  'Sábado' ]
+
 ```
 
 ### Get an array of weeks in this month

--- a/index.js
+++ b/index.js
@@ -1,33 +1,92 @@
 "use strict";
 
-var DAYNAMES = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday"
-];
+var DAYNAMES = {
+  english: [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ],
+  french: [
+    "Dimanche",
+    "Lundi",
+    "Mardi",
+    "Mercredi",
+    "Jeudi",
+    "Vendredi",
+    "Samedi"
+  ],
+  spanish: [
+    "Domingo",
+    "Lunes",
+    "Martes",
+    "Miércoles",
+    "Jueves",
+    "Viernes",
+    "Sábado"
+  ]
+};
 
-var MONTHNAMES = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December"
-];
+var MONTHNAMES = {
+  english: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+  ],
+  french: [
+    "Janvier",
+    "Février",
+    "Mars",
+    "Avril",
+    "Mai",
+    "Juin",
+    "Juillet",
+    "Août",
+    "Septembre",
+    "Octobre",
+    "Novembre",
+    "Décembre"
+  ],
+  spanish: [
+    "Enero",
+    "Febrero",
+    "Marzo",
+    "Abril",
+    "Mayo",
+    "Junio",
+    "Julio",
+    "Agosto",
+    "Septiembre",
+    "Octubre",
+    "Noviembre",
+    "Diciembre"
+  ]
+};
+
+const LANGUAGES = {
+  english: "english",
+  french: "french",
+  spanish: "spanish"
+};
 
 class Calendar {
   constructor(params = {}) {
     const now = params.today || new Date();
+
+    // filter language
+    params.language = LANGUAGES[params.language] || LANGUAGES.english;
 
     const defaults = {
       year: now.getFullYear(),
@@ -41,7 +100,8 @@ class Calendar {
 
     this.options = Object.assign({}, defaults, params);
 
-    this.monthNames = MONTHNAMES;
+    this.monthNames = MONTHNAMES[this.options.language];
+    this.dayNames = DAYNAMES[this.options.language];
 
     this.today = this.createDate(
       now.getFullYear(),
@@ -55,8 +115,8 @@ class Calendar {
     data.dayNames = [];
 
     // Abbreviate the day names when configured to do so.
-    for (var index = 0, len = DAYNAMES.length; index < len; index++) {
-      var dayName = DAYNAMES[index];
+    for (var index = 0, len = this.dayNames.length; index < len; index++) {
+      var dayName = this.dayNames[index];
       var dayAbbr = dayName.substr(0, this.options.abbreviate);
 
       if (dayAbbr !== dayName) {
@@ -182,11 +242,11 @@ class Calendar {
   }
 
   getDayName(index) {
-    return DAYNAMES[index];
+    return this.dayNames[index];
   }
 
   getMonthName(index) {
-    return MONTHNAMES[index];
+    return this.monthNames[index];
   }
 
   getRelativeMonth(date, dif) {
@@ -195,7 +255,7 @@ class Calendar {
 
     if (newIndex < 0) newIndex = 11;
     else if (newIndex > 11) newIndex = 1;
-    return MONTHNAMES[newIndex];
+    return this.monthNames[newIndex];
   }
 
   isWeekend(date) {

--- a/test.js
+++ b/test.js
@@ -99,3 +99,259 @@ describe("uses firstDayOfWeek param", () => {
     expect(calendar.weeks[0][0].day).toBe(28);
   });
 });
+
+describe("language parameter in constructor", () => {
+  test("constructor optionally accepts a language", () => {
+    let calendar = new JsonCalendar({ language: 'french' });
+    expect(calendar.options.language).toBe("french");
+
+    calendar = new JsonCalendar();
+    expect(calendar.options.language).toBe("english");
+  });
+
+  test("optional language param accept french or spanish, otherwise defaults to english", () => {
+    let calendar = new JsonCalendar({ language: "spanish" });
+    expect(calendar.options.language).toBe("spanish");
+
+    calendar = new JsonCalendar({ language: "french" });
+    expect(calendar.options.language).toBe("french");
+
+    calendar = new JsonCalendar({ language: "esperanto" });
+    expect(calendar.options.language).toBe("english");
+
+  });
+});
+
+describe("language for months name", () => {
+  test("should return french month names", () => {
+    const calendar = new JsonCalendar({ language: "french" });
+
+    const janvier = calendar.getMonthName(0);
+    const fevrier = calendar.getMonthName(1);
+    const mars = calendar.getMonthName(2);
+    const avril = calendar.getMonthName(3);
+    const mai = calendar.getMonthName(4);
+    const juin = calendar.getMonthName(5);
+    const juillet = calendar.getMonthName(6);
+    const aout = calendar.getMonthName(7);
+    const septembre = calendar.getMonthName(8);
+    const octobre = calendar.getMonthName(9);
+    const novembre = calendar.getMonthName(10);
+    const decembre = calendar.getMonthName(11);
+
+    expect(janvier).toBe("Janvier");
+    expect(fevrier).toBe("Février");
+    expect(mars).toBe("Mars");
+    expect(avril).toBe("Avril");
+    expect(mai).toBe("Mai");
+    expect(juin).toBe("Juin");
+    expect(juillet).toBe("Juillet");
+    expect(aout).toBe("Août");
+    expect(septembre).toBe("Septembre");
+    expect(octobre).toBe("Octobre");
+    expect(novembre).toBe("Novembre");
+    expect(decembre).toBe("Décembre");
+
+    expect(calendar.monthNames).toEqual(expect.arrayContaining([
+      "Janvier",
+      "Février",
+      "Mars",
+      "Avril",
+      "Mai",
+      "Juin",
+      "Juillet",
+      "Août",
+      "Septembre",
+      "Octobre",
+      "Novembre",
+      "Décembre"
+    ]));
+
+  });
+
+  test("should return spanish month name", () => {
+    const calendar = new JsonCalendar({ language: "spanish" });
+
+    const enero = calendar.getMonthName(0);
+    const febrero = calendar.getMonthName(1);
+    const marzo = calendar.getMonthName(2);
+    const abril = calendar.getMonthName(3);
+    const mayo = calendar.getMonthName(4);
+    const junio = calendar.getMonthName(5);
+    const julio = calendar.getMonthName(6);
+    const agosto = calendar.getMonthName(7);
+    const septiembre = calendar.getMonthName(8);
+    const octubre = calendar.getMonthName(9);
+    const noviembre = calendar.getMonthName(10);
+    const diciembre = calendar.getMonthName(11);
+
+    expect(enero).toBe("Enero");
+    expect(febrero).toBe("Febrero");
+    expect(marzo).toBe("Marzo");
+    expect(abril).toBe("Abril");
+    expect(mayo).toBe("Mayo");
+    expect(junio).toBe("Junio");
+    expect(julio).toBe("Julio");
+    expect(agosto).toBe("Agosto");
+    expect(septiembre).toBe("Septiembre");
+    expect(octubre).toBe("Octubre");
+    expect(noviembre).toBe("Noviembre");
+    expect(diciembre).toBe("Diciembre");
+
+    expect(calendar.monthNames).toEqual(expect.arrayContaining([
+      "Enero",
+      "Febrero",
+      "Marzo",
+      "Abril",
+      "Mayo",
+      "Junio",
+      "Julio",
+      "Agosto",
+      "Septiembre",
+      "Octubre",
+      "Noviembre",
+      "Diciembre"
+    ]));
+
+  });
+
+  test("should return english month name", () => {
+    // by default => english
+    const calendar = new JsonCalendar();
+
+    const january = calendar.getMonthName(0);
+    const february = calendar.getMonthName(1);
+    const march = calendar.getMonthName(2);
+    const april = calendar.getMonthName(3);
+    const may = calendar.getMonthName(4);
+    const june = calendar.getMonthName(5);
+    const july = calendar.getMonthName(6);
+    const august = calendar.getMonthName(7);
+    const septembre = calendar.getMonthName(8);
+    const octobre = calendar.getMonthName(9);
+    const novembre = calendar.getMonthName(10);
+    const decembre = calendar.getMonthName(11);
+
+    expect(january).toBe("January");
+    expect(february).toBe("February");
+    expect(march).toBe("March");
+    expect(april).toBe("April");
+    expect(may).toBe("May");
+    expect(june).toBe("June");
+    expect(july).toBe("July");
+    expect(august).toBe("August");
+    expect(septembre).toBe("September");
+    expect(octobre).toBe("October");
+    expect(novembre).toBe("November");
+    expect(decembre).toBe("December");
+
+    expect(calendar.monthNames).toEqual(expect.arrayContaining([
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December"
+    ]));
+
+  });
+});
+
+describe("language for day name", () => {
+  test("should return french day names", () => {
+    const calendar = new JsonCalendar({ language: "french" });
+
+    const dimanche = calendar.getDayName(0);
+    const lundi = calendar.getDayName(1);
+    const mardi = calendar.getDayName(2);
+    const mercredi = calendar.getDayName(3);
+    const jeudi = calendar.getDayName(4);
+    const vendredi = calendar.getDayName(5);
+    const samedi = calendar.getDayName(6);
+
+    expect(dimanche).toBe("Dimanche");
+    expect(lundi).toBe("Lundi");
+    expect(mardi).toBe("Mardi");
+    expect(mercredi).toBe("Mercredi");
+    expect(jeudi).toBe("Jeudi");
+    expect(vendredi).toBe("Vendredi");
+    expect(samedi).toBe("Samedi");
+
+    expect(calendar.dayNames).toEqual(expect.arrayContaining([
+      "Dimanche",
+      "Lundi",
+      "Mardi",
+      "Mercredi",
+      "Jeudi",
+      "Vendredi",
+      "Samedi"
+    ]));
+  });
+
+  test("should return spanish day names", () => {
+    const calendar = new JsonCalendar({ language: "spanish" });
+
+    const domingo = calendar.getDayName(0);
+    const lunes = calendar.getDayName(1);
+    const martes = calendar.getDayName(2);
+    const miercole = calendar.getDayName(3);
+    const jueves = calendar.getDayName(4);
+    const viernes = calendar.getDayName(5);
+    const sabado = calendar.getDayName(6);
+
+    expect(domingo).toBe("Domingo");
+    expect(lunes).toBe("Lunes");
+    expect(martes).toBe("Martes");
+    expect(miercole).toBe("Miércoles");
+    expect(jueves).toBe("Jueves");
+    expect(viernes).toBe("Viernes");
+    expect(sabado).toBe("Sábado");
+
+    expect(calendar.dayNames).toEqual(expect.arrayContaining([
+      "Domingo",
+      "Lunes",
+      "Martes",
+      "Miércoles",
+      "Jueves",
+      "Viernes",
+      "Sábado"
+    ]));
+  });
+
+  test("should return english day names", () => {
+    // by default => english
+    const calendar = new JsonCalendar();
+
+    const sunday = calendar.getDayName(0);
+    const monday = calendar.getDayName(1);
+    const tuesday = calendar.getDayName(2);
+    const wednesday = calendar.getDayName(3);
+    const thursday = calendar.getDayName(4);
+    const friday = calendar.getDayName(5);
+    const saturday = calendar.getDayName(6);
+
+    expect(sunday).toBe("Sunday");
+    expect(monday).toBe("Monday");
+    expect(tuesday).toBe("Tuesday");
+    expect(wednesday).toBe("Wednesday");
+    expect(thursday).toBe("Thursday");
+    expect(friday).toBe("Friday");
+    expect(saturday).toBe("Saturday");
+
+    expect(calendar.dayNames).toEqual(expect.arrayContaining([
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday"
+    ]));
+  });
+});


### PR DESCRIPTION
…eed for client to translate to other languages.

* Adapted code base to support optional 'language' parameters in
constructor.
* Supports for 'english', 'french' and 'spanish' as a json field of
params, will default to english if 'language' field is empty or
unrecognized.

* Unit tests, boosted coverage
* Updated README