### PR TITLE
Function for getting days in month doesn’t need to be an instance method

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@rxgx/json-calendar",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1547,9 +1547,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.2.0.tgz",
-      "integrity": "sha512-VLsgK/D+S/FEsda7Um1+N8FThec6LqE3vhcMyp8mlmto97y3fGf3DX7byJexGuOb1QY0Z/zz222U5t+xSfcZDQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
+      "integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -4268,7 +4268,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5706,9 +5706,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rxgx/json-calendar",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A data model for displaying dates and date ranges on a calendar interface.",
   "keywords": [
     "json",
@@ -43,14 +43,14 @@
     "@typescript-eslint/parser": "^2.2.0",
     "eslint": "^6.3.0",
     "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-config-prettier": "^6.2.0",
+    "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-prettier": "^3.1.0",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.6.2"
+    "typescript": "^3.6.3"
   },
   "dependencies": {}
 }

--- a/src/getDaysInMonth.test.ts
+++ b/src/getDaysInMonth.test.ts
@@ -1,0 +1,10 @@
+import getDaysInMonth from './getDaysInMonth';
+
+test('get days in month', () => {
+  expect(getDaysInMonth(2018, 4)).toBe(31);
+  expect(getDaysInMonth(2018, 8)).toBe(30);
+  // non-leap year
+  expect(getDaysInMonth(2009, 1)).toBe(28);
+  // leap year
+  expect(getDaysInMonth(2008, 1)).toBe(29);
+});

--- a/src/getDaysInMonth.ts
+++ b/src/getDaysInMonth.ts
@@ -1,0 +1,3 @@
+export default function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -72,16 +72,6 @@ test('displays October 2018 correctly', () => {
   expect(calendar.weeks[0][1].date.getMonth()).toBe(9);
 });
 
-test('get days in month', () => {
-  const subject = new JsonCalendar({ today: new Date(2015, 4, 23) });
-  expect(subject.getDaysInMonth(2018, 4)).toBe(31);
-  expect(subject.getDaysInMonth(2018, 8)).toBe(30);
-  // non-leap year
-  expect(subject.getDaysInMonth(2009, 1)).toBe(28);
-  // leap year
-  expect(subject.getDaysInMonth(2008, 1)).toBe(29);
-});
-
 test('accepts change month', () => {
   const calendar = new JsonCalendar();
   calendar.changeMonth(2019, 3);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import createDate from './createDate';
+import getDaysInMonth from './getDaysInMonth';
 import isWeekend from './isWeekend';
 import dictionary from './dictionary';
 
@@ -134,7 +135,7 @@ export default class JsonCalendar {
     const { options } = this;
 
     const firstDate = createDate(options.year, options.monthIndex, 1);
-    const monthDays = this.getDaysInMonth(options.year, options.monthIndex);
+    const monthDays = getDaysInMonth(options.year, options.monthIndex);
     const firstDateIndex = firstDate.getDay();
 
     // Loop through week indexes (0..6)
@@ -197,10 +198,6 @@ export default class JsonCalendar {
     this.options.year = year;
     this.options.monthIndex = monthIndex;
     this.buildWeeksArray();
-  }
-
-  getDaysInMonth(year: number, month: number): number {
-    return new Date(year, month + 1, 0).getDate();
   }
 
   getDayAbbr(index: number): string {


### PR DESCRIPTION
## What’s Changed?

- `getDaysInMonth` was incorrectly taking from instance state
- update eslint config
- update typescript
- patch version bump
 