### PR TITLE
fix: make sure weeks array is reset

### DIFF
--- a/src/createDate.test.ts
+++ b/src/createDate.test.ts
@@ -1,11 +1,23 @@
 import createDate from './createDate'
 
-test('creates a date without time', () => {
+test('creates a date in the future', () => {
   const date = createDate(2018, 11, 32)
   expect(date instanceof Date).toBe(true)
+  expect(date.toDateString()).toBe('Tue Jan 01 2019')
   expect(date.getFullYear()).toBe(2019)
   expect(date.getMonth()).toBe(0)
   expect(date.getDate()).toBe(1)
+  expect(date.getMinutes()).toBe(0)
+  expect(date.getHours()).toBe(0)
+})
+
+test('creates a valid date', () => {
+  const date = createDate(2024, 5, 20)
+  expect(date instanceof Date).toBe(true)
+  expect(date.toDateString()).toBe('Thu Jun 20 2024')
+  expect(date.getFullYear()).toBe(2024)
+  expect(date.getMonth()).toBe(5)
+  expect(date.getDate()).toBe(20)
   expect(date.getMinutes()).toBe(0)
   expect(date.getHours()).toBe(0)
 })

--- a/src/createDate.ts
+++ b/src/createDate.ts
@@ -1,3 +1,3 @@
-export = function createDate (yr: number, mo: number, day: number): Date {
-  return new Date(yr, mo, day, 0, 0)
+export = function createDate (year: number, monthIndex: number, day: number): Date {
+  return new Date(year, monthIndex, day, 0, 0)
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -77,6 +77,9 @@ test('accepts change month', () => {
   calendar.changeMonth(2019, 3)
   expect(calendar.options.monthIndex).toBe(3)
   expect(calendar.options.year).toBe(2019)
+  expect(calendar.weeks.length).toBe(6)
+  expect(calendar.weeks[1][0].monthIndex).toBe(3)
+  expect(calendar.weeks[1][0].year).toBe(2019)
 })
 
 describe('uses firstDayOfWeek param', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ export class JsonCalendar {
     const monthDays = getDaysInMonth(options.year, options.monthIndex)
     const firstDateIndex = firstDate.getDay()
 
+    this.weeks = []
     // Loop through week indexes (0..6)
     for (let w = 0; w < 6; w += 1) {
       let date: Date
@@ -157,7 +158,7 @@ export class JsonCalendar {
           className: classNames.join(' '),
           id: `day${date.getTime()}`,
           day: date.getDate(),
-          date: date,
+          date,
           monthIndex: date.getMonth(),
           year: date.getFullYear()
         }


### PR DESCRIPTION
### What's changed?

- make sure `month` is used as `monthIndex`
- make sure `weeks` array is reset when `changeMonth` is called

Resolves #835 